### PR TITLE
feat: add warning message to renovate_dependency metric

### DIFF
--- a/pkg/parser/repository.go
+++ b/pkg/parser/repository.go
@@ -17,12 +17,12 @@ type repository struct {
 }
 
 type packageDefinition struct {
-	Repository     string
 	DependencyName string
 	CurrentVersion string
 	DependencyType string
 	PackageFile    string
 	Manager        string
+	WarningMessage string
 }
 
 type packageUpdate struct {
@@ -38,7 +38,7 @@ func NewRepository(repo string) *repository {
 		ConstLabels: prometheus.Labels{
 			"repository": repo,
 		},
-	}, []string{"manager", "packageFile", "depName", "depType", "currentVersion"})
+	}, []string{"manager", "packageFile", "depName", "depType", "currentVersion", "warning"})
 
 	dependencyUpdateMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "renovate",
@@ -95,6 +95,7 @@ func (p *repository) packageDefinition(metric *prometheus.GaugeVec, definition p
 		"depName":        definition.DependencyName,
 		"depType":        definition.DependencyType,
 		"currentVersion": definition.CurrentVersion,
+		"warning":        definition.WarningMessage,
 	})
 
 	m.Set(1)
@@ -138,12 +139,20 @@ func (p *repository) Parse(line logLine) error {
 		for manager, files := range *line.Config {
 			for _, packageDependency := range files {
 				for _, dep := range packageDependency.Deps {
+					warningMessage := ""
+					for _, w := range dep.Warnings {
+						if w.Topic == dep.DepName {
+							warningMessage = w.Message
+							break
+						}
+					}
 					p.packageDefinition(p.dependencyMetric, packageDefinition{
 						DependencyName: dep.DepName,
 						CurrentVersion: dep.CurrentValue,
 						DependencyType: dep.DepType,
 						Manager:        manager,
 						PackageFile:    packageDependency.PackageFile,
+						WarningMessage: warningMessage,
 					})
 
 					for _, update := range dep.Updates {


### PR DESCRIPTION
<img width="1819" alt="Screenshot 2024-12-12 at 11 19 52" src="https://github.com/user-attachments/assets/a6cc5d21-513a-4d51-be21-e6428f041827" />

adds warning on this depName to the labels of renovate_dependency metric.

Use Case: I want to create an alert if warning != ""