### PR TITLE
fix: fix metric duplication and remove obsolete r label

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -51,10 +51,10 @@ func init() {
 				return err
 			}
 
-			client := push.New(prometheusArg, "renovate")
-
 			for repository, collector := range collectors {
-				client.Grouping("r", repository)
+				// Note: Client can't be reused, as there is no way to unregister a Collector from a Pusher.
+				client := push.New(prometheusArg, "renovate")
+				client.Grouping("repository", repository)
 
 				if err := client.Delete(); err != nil {
 					return err

--- a/pkg/parser/repository.go
+++ b/pkg/parser/repository.go
@@ -35,27 +35,18 @@ func NewRepository(repo string) *repository {
 		Namespace: "renovate",
 		Name:      "dependency",
 		Help:      "Installed dependency",
-		ConstLabels: prometheus.Labels{
-			"repository": repo,
-		},
 	}, []string{"manager", "packageFile", "depName", "depType", "currentVersion"})
 
 	dependencyUpdateMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "renovate",
 		Name:      "dependency_update",
 		Help:      "Available update of an installed dependency",
-		ConstLabels: prometheus.Labels{
-			"repository": repo,
-		},
 	}, []string{"manager", "packageFile", "depName", "depType", "currentVersion", "updateType", "newVersion", "vulnerabilityFix", "releaseTimestamp"})
 
 	lastSuccessfulRunMetric := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "renovate",
 		Name:      "last_successful_timestamp",
 		Help:      "Timestamp of the last successful execution",
-		ConstLabels: prometheus.Labels{
-			"repository": repo,
-		},
 	})
 
 	return &repository{


### PR DESCRIPTION
Hi @raffis,
I noticed that there are a lot of metrics with r!=repository. This stems from the fact, that the Pusher never unregisters the collectors that are added to it. So pushing metrics for a new repository will also include all metrics from all previous repositories.

As the Pusher does not have a way to unregistered collectors, this change creates a new Pusher per repository.

I also removed the `r` label, as it always is equal to `repository`.

I tested and verified my changes with a local prometheus/pushgateway setup.

Would be great to have this merged and released soon.

Note: This PR recreates #60 based upon a different source branch.