### PR TITLE
feat: support multiple renovate branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 bin
 coverage.out
+.DS_Store


### PR DESCRIPTION
Changes:
* support multiple renovate branches by adding baseBranch as label
* ignore .DS_Store files in .gitignore

It would be possible to add another flag to use multi-branch support as an opt-in feature.

