### PR TITLE
fix: prevent panic because of duplicate metrics

### DIFF
--- a/pkg/parser/repository.go
+++ b/pkg/parser/repository.go
@@ -102,12 +102,18 @@ func (p *repository) packageDefinition(metric *prometheus.GaugeVec, definition p
 }
 
 func (p *repository) packageUpdate(metric *prometheus.GaugeVec, update packageUpdate) prometheus.Gauge {
+	// There may be different updates for the same package in separate branches. We still want only one metric
+	// for it, so we reset the branch name here prior to the lookup in p.packageUpdates.
+	// Without this prometheus/client_golang will panic because of duplicate metrics.
+	branchName := update.BranchName
+	update.BranchName = ""
+
 	if m, has := p.packageUpdates[update]; has {
 		m.Inc()
 		return m
 	}
 
-	isVulnerabilityUpdate, _ := regexp.MatchString(`-vulnerability$`, update.BranchName)
+	isVulnerabilityUpdate, _ := regexp.MatchString(`-vulnerability$`, branchName)
 	ts, err := time.Parse(time.RFC3339, update.ReleaseTimestamp)
 	if err != nil {
 		ts = time.Unix(0, 0)


### PR DESCRIPTION
When the same dependency is referenced twice in the same file, and renovate is configured to create separate PRs for the two references, renovate-metrics will have two packageUpdate structs which are different, but emit the same metric.

This will lead to a panic:
> panic: [from Gatherer #1] collected metric "renovate_dependency_update" { … } was collected before with the same name and label values

With this change the branch name is copied to a local variable for later usage and set to an empty string for the comparison happening on map access. Thus the existing metric will be found and increased.