### PR TITLE
fix: skip lines that are not relevant

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -44,6 +44,9 @@ func (p *parser) Parse() (map[string]*repository, error) {
 			if line.Repository == "" {
 				continue
 			}
+			if line.Config == nil && line.Message != "Repository finished" {
+				continue
+			}
 
 			repository := p.repository(line.Repository)
 			if err := repository.Parse(line); err != nil {


### PR DESCRIPTION
Some lines contain the upstream dependency as repo name, which leads to metrics being emitted for these (unrenovated) repos.

With this change renovate-metrics only handles lines which have a config, and additionally just keeps the required "Repository finished" message.

Example: 
```
{
  name: "renovate",
  hostname: "renovate-4-29624280-rpzbq",
  pid: 8,
  level: 20,
  logContext: "92db41dd-1275-4319-978c-b76f0e50036b",
  repository: "connect2id/nimbus-jose-jwt",
  branch: "renovate/major-jwtversion",
  type: "bitbucket",
  apiBaseUrl: https://api.bitbucket.org/,
  msg: "Error 404 getting changelog md",
  time: "2026-04-29T10:23:51.569Z",
  v: 0
}
```