### PR TITLE
feat: add metrics and panel for branch info metrics, add warnings panel

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -2599,6 +2599,18 @@
                 "value": 463
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time ago"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 227
+              }
+            ]
           }
         ]
       },
@@ -2640,7 +2652,12 @@
             "excludeByName": {
               "Time": true
             },
-            "indexByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 1,
+              "repository": 2
+            },
             "renameByName": {
               "Value": "Time ago",
               "repository": "Repository"
@@ -2713,7 +2730,31 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 463
+                "value": 380
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Branch"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 235
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PR #"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 50
               }
             ]
           }
@@ -2772,7 +2813,9 @@
             },
             "renameByName": {
               "Value": "PR #",
-              "repository": "Repository"
+              "branch": "Branch",
+              "repository": "Repository",
+              "result": "Result"
             }
           }
         },
@@ -2784,6 +2827,130 @@
               {
                 "desc": true,
                 "field": "result"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "repository"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 340
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 95
+      },
+      "id": 41,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "renovate_dependency{warning!=\"\", repository=~\"$repository\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Warnings",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "baseBranch": true,
+              "cluster": true,
+              "currentVersion": true,
+              "depName": true,
+              "depType": true,
+              "isAbandoned": true,
+              "job": true,
+              "manager": true,
+              "packageFile": true,
+              "packageName": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 1,
+              "repository": 2
+            },
+            "renameByName": {
+              "Value": "",
+              "repository": "Repository",
+              "warning": "Warning"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Time ago"
               }
             ]
           }

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -2591,7 +2591,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Respository"
+              "options": "Repository"
             },
             "properties": [
               {
@@ -2643,8 +2643,149 @@
             "indexByName": {},
             "renameByName": {
               "Value": "Time ago",
-              "repository": "Respository"
+              "repository": "Repository"
             }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "transparent",
+                        "index": 0,
+                        "text": "-"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Repository"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 463
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 15,
+        "x": 9,
+        "y": 85
+      },
+      "id": 40,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "renovate_branch{repository=~\"$repository\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Branch information",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true,
+              "job": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 6,
+              "__name__": 2,
+              "branch": 3,
+              "job": 4,
+              "repository": 1,
+              "result": 5
+            },
+            "renameByName": {
+              "Value": "PR #",
+              "repository": "Repository"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "result"
+              }
+            ]
           }
         }
       ],

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"io"
 
@@ -39,12 +40,14 @@ func (p *parser) Parse() (map[string]*repository, error) {
 	scanner.Buffer(b, p.opts.BufferSize)
 	for scanner.Scan() {
 		var line logLine
-		err := json.Unmarshal(scanner.Bytes(), &line)
+		rawLine := scanner.Bytes()
+		if !bytes.Contains(rawLine, []byte(PackageFileUpdatesMessage)) && !bytes.Contains(rawLine, []byte(RepositoryFinishedMessage)) && !bytes.Contains(rawLine, []byte(BranchesInfoMessage)) {
+			continue
+		}
+
+		err := json.Unmarshal(rawLine, &line)
 		if err == nil {
 			if line.Repository == "" {
-				continue
-			}
-			if line.Config == nil && line.Message != "Repository finished" {
 				continue
 			}
 

--- a/pkg/parser/renovate.go
+++ b/pkg/parser/renovate.go
@@ -2,18 +2,25 @@ package parser
 
 import "encoding/json"
 
+const (
+	RepositoryFinishedMessage = "Repository finished"
+	PackageFileUpdatesMessage = "packageFiles with updates"
+	BranchesInfoMessage       = "branches info extended"
+)
+
 type logLine struct {
-	Name              string                          `json:"name,omitempty"`
-	Hostname          string                          `json:"hostname,omitempty"`
-	PID               int                             `json:"pid,omitempty"`
-	Level             int                             `json:"level,omitempty"`
-	Message           string                          `json:"msg,omitempty"`
-	LogContext        string                          `json:"logContext,omitempty"`
-	Time              string                          `json:"time,omitempty"`
-	Repository        string                          `json:"repository,omitempty"`
-	BaseBranch        string                          `json:"baseBranch,omitempty"`
-	Config            *map[string][]packageDependency `json:"config,omitempty"`
-	AlertPackageRules []alertPackageRule              `json:"alertPackageRules,omitempty"`
+	Name                string                          `json:"name,omitempty"`
+	Hostname            string                          `json:"hostname,omitempty"`
+	PID                 int                             `json:"pid,omitempty"`
+	Level               int                             `json:"level,omitempty"`
+	Message             string                          `json:"msg,omitempty"`
+	LogContext          string                          `json:"logContext,omitempty"`
+	Time                string                          `json:"time,omitempty"`
+	Repository          string                          `json:"repository,omitempty"`
+	BaseBranch          string                          `json:"baseBranch,omitempty"`
+	Config              *map[string][]packageDependency `json:"config,omitempty"`
+	AlertPackageRules   []alertPackageRule              `json:"alertPackageRules,omitempty"`
+	BranchesInformation []branchInformation             `json:"branchesInformation,omitempty"`
 }
 
 type alertPackageRule struct {
@@ -59,6 +66,13 @@ type update struct {
 	UpdateType       string `json:"updateType,omitempty"`
 	NewDigest        string `json:"newDigest,omitempty"`
 	BranchName       string `json:"branchName,omitempty"`
+}
+
+type branchInformation struct {
+	BranchName string `json:"branchName"`
+	PrNo       *int   `json:"prNo"`
+	PrTitle    string `json:"prTitle"`
+	Result     string `json:"result"`
 }
 
 type boolString string

--- a/pkg/parser/repository.go
+++ b/pkg/parser/repository.go
@@ -9,9 +9,11 @@ import (
 )
 
 type repository struct {
+	branchMetric            *prometheus.GaugeVec
 	dependencyMetric        *prometheus.GaugeVec
 	dependencyUpdateMetric  *prometheus.GaugeVec
 	lastSuccessfulRunMetric prometheus.Gauge
+	branchInformation       map[branchInformation]prometheus.Gauge
 	packageDefinitions      map[packageDefinition]prometheus.Gauge
 	packageUpdates          map[packageUpdate]prometheus.Gauge
 }
@@ -34,6 +36,12 @@ type packageUpdate struct {
 }
 
 func NewRepository(repo string) *repository {
+
+	branchMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "renovate",
+		Name:      "branch",
+		Help:      "Branch information",
+	}, []string{"branch", "result"})
 	dependencyMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "renovate",
 		Name:      "dependency",
@@ -53,9 +61,11 @@ func NewRepository(repo string) *repository {
 	})
 
 	return &repository{
+		branchMetric:            branchMetric,
 		dependencyMetric:        dependencyMetric,
 		dependencyUpdateMetric:  dependencyUpdateMetric,
 		lastSuccessfulRunMetric: lastSuccessfulRunMetric,
+		branchInformation:       make(map[branchInformation]prometheus.Gauge),
 		packageDefinitions:      make(map[packageDefinition]prometheus.Gauge),
 		packageUpdates:          make(map[packageUpdate]prometheus.Gauge),
 	}
@@ -68,6 +78,10 @@ func (p *repository) Describe(ch chan<- *prometheus.Desc) {
 func (p *repository) Collect(ch chan<- prometheus.Metric) {
 	ch <- p.lastSuccessfulRunMetric
 
+	for _, m := range p.branchInformation {
+		ch <- m
+	}
+
 	for _, m := range p.packageDefinitions {
 		ch <- m
 	}
@@ -75,6 +89,21 @@ func (p *repository) Collect(ch chan<- prometheus.Metric) {
 	for _, m := range p.packageUpdates {
 		ch <- m
 	}
+}
+
+func (p *repository) branchInfo(metric *prometheus.GaugeVec, definition branchInformation) prometheus.Gauge {
+	prNo := 0
+	if definition.PrNo != nil {
+		prNo = *definition.PrNo
+	}
+	m := metric.With(prometheus.Labels{
+		"branch": definition.BranchName,
+		"result": definition.Result,
+	})
+
+	m.Set(float64(prNo))
+	p.branchInformation[definition] = m
+	return m
 }
 
 func (p *repository) packageDefinition(metric *prometheus.GaugeVec, definition packageDefinition) prometheus.Gauge {
@@ -141,6 +170,12 @@ func (p *repository) packageUpdate(metric *prometheus.GaugeVec, update packageUp
 
 func (p *repository) Parse(line logLine) error {
 	switch {
+	case line.BranchesInformation != nil:
+		for _, branchInfo := range line.BranchesInformation {
+			if branchInfo.Result != "" {
+				p.branchInfo(p.branchMetric, branchInfo)
+			}
+		}
 	case line.Config != nil:
 		for manager, files := range *line.Config {
 			for _, packageDependency := range files {
@@ -182,7 +217,7 @@ func (p *repository) Parse(line logLine) error {
 				}
 			}
 		}
-	case line.Message == "Repository finished":
+	case line.Message == RepositoryFinishedMessage:
 		ts, err := time.Parse(time.RFC3339, line.Time)
 
 		if err != nil {


### PR DESCRIPTION
This change adds emitting branch info metrics. These include the repository and branch, the result and optionally the PR # as metric value.

`result` may have one of these values:
 - already-existed - updates are blocked by an existing closed PR
 - branch-limit-reached - updates are currently rate-limited
 - pr-limit-reached - updates are currently rate-limited
 - commit-per-run-limit-reached - updates are currently rate-limited
 - commit-hourly-limit-reached - updates are currently rate-limited
 - branch-limit-reached - updates are currently rate-limited
 - branch-limit-reached - updates are currently rate-limited
 - needs-approval - branch creation is pending approval
 - needs-pr-approval - branch exists but PR creation requires approval
 - minimum-group-size-not-met - branch has not met its minimum group size
 - done - PR has been created
 - no-work - nothing to do
 - not-scheduled - updates are awaiting their schedule
 - pending - updates await pending status checks
 - pr-edited - branch has been manually edited so Renovate will no longer make changes
 - error - renovate encountered an error during branch creation

A new panel with this data has been added to the dashboard.

<img width="1398" height="411" alt="image" src="https://github.com/user-attachments/assets/25a181f4-9567-4d1d-bf0e-59c2da100290" />


This also adds a warning panel for failed dependency updates:

<img width="1404" height="423" alt="image" src="https://github.com/user-attachments/assets/18147090-180d-4f37-af79-660c92d4fbf8" />
