### PR TITLE
feat: add pending label to renovate_dependency_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This is possible if renovate runs in self-hosted environments.
 `renovate_dependency` labels: "repository", "manager", "packageFile", "depName", "currentVersion", "warning", "baseBranch"
    
 * Available update of an installed dependency \
-`renovate_dependency_update` labels: "repository", "manager", "packageFile", "depName", "currentVersion", "updateType", "newVersion", "vulnerabilityFix", "releaseTimestamp", "baseBranch"
+`renovate_dependency_update` labels: "repository", "manager", "packageFile", "depName", "currentVersion", "updateType", "newVersion", "vulnerabilityFix", "releaseTimestamp", "baseBranch", "pending" \
+(`pending="true"` when Renovate is withholding the update via internal checks such as `minimumReleaseAge`; combined with `releaseTimestamp="0"` this identifies updates blocked because the release has no timestamp)
    
 * Timestamp of the last successful execution \
 `renovate_last_successful_timestamp` labels: "repository"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ This is possible if renovate runs in self-hosted environments.
 `renovate_dependency` labels: "repository", "manager", "packageFile", "depName", "currentVersion", "warning", "baseBranch"
    
 * Available update of an installed dependency \
-`renovate_dependency_update` labels: "repository", "manager", "packageFile", "depName", "currentVersion", "updateType", "newVersion", "vulnerabilityFix", "releaseTimestamp", "baseBranch", "pending" \
-(`pending="true"` when Renovate is withholding the update via internal checks such as `minimumReleaseAge`; combined with `releaseTimestamp="0"` this identifies updates blocked because the release has no timestamp)
+`renovate_dependency_update` labels: "repository", "manager", "packageFile", "depName", "currentVersion", "updateType", "newVersion", "vulnerabilityFix", "releaseTimestamp", "baseBranch", "pending"
    
 * Timestamp of the last successful execution \
 `renovate_last_successful_timestamp` labels: "repository"

--- a/pkg/parser/renovate.go
+++ b/pkg/parser/renovate.go
@@ -61,6 +61,7 @@ type update struct {
 	NewVersion       string `json:"newVersion,omitempty"`
 	NewValue         string `json:"newValue,omitempty"`
 	ReleaseTimestamp string `json:"releaseTimestamp,omitempty"`
+	PendingChecks    bool   `json:"pendingChecks,omitempty"`
 	NewMajor         int    `json:"newMajor,omitempty"`
 	NewMinor         int    `json:"newMinor,omitempty"`
 	UpdateType       string `json:"updateType,omitempty"`

--- a/pkg/parser/repository.go
+++ b/pkg/parser/repository.go
@@ -52,7 +52,7 @@ func NewRepository(repo string) *repository {
 		Namespace: "renovate",
 		Name:      "dependency_update",
 		Help:      "Available update of an installed dependency",
-	}, []string{"manager", "packageFile", "depName", "packageName", "depType", "currentVersion", "updateType", "newVersion", "vulnerabilityFix", "releaseTimestamp", "baseBranch", "isAbandoned"})
+	}, []string{"manager", "packageFile", "depName", "packageName", "depType", "currentVersion", "updateType", "newVersion", "vulnerabilityFix", "releaseTimestamp", "baseBranch", "isAbandoned", "pending"})
 
 	lastSuccessfulRunMetric := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "renovate",
@@ -161,6 +161,7 @@ func (p *repository) packageUpdate(metric *prometheus.GaugeVec, update packageUp
 		"releaseTimestamp": strconv.FormatInt(ts.Unix(), 10),
 		"baseBranch":       update.BaseBranch,
 		"isAbandoned":      update.IsAbandoned,
+		"pending":          strconv.FormatBool(update.PendingChecks),
 	})
 	m.Set(1)
 	p.packageUpdates[update] = m

--- a/pkg/parser/repository_test.go
+++ b/pkg/parser/repository_test.go
@@ -1,0 +1,81 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// findUpdateSeries returns the label set of the first renovate_dependency_update
+// series whose depName matches, or nil if none is found.
+func findUpdateSeries(t *testing.T, r prometheus.Collector, depName string) map[string]string {
+	t.Helper()
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(r)
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "renovate_dependency_update" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			if labels["depName"] == depName {
+				return labels
+			}
+		}
+	}
+	return nil
+}
+
+func parseLine(t *testing.T, line string) *repository {
+	t.Helper()
+	p := NewParser(strings.NewReader(line), ParserOptions{BufferSize: 1024 * 1024, Logger: logr.Discard()})
+	repos, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	r, ok := repos["acme/repo"]
+	if !ok {
+		t.Fatalf("repository acme/repo not found in %v", repos)
+	}
+	return r
+}
+
+// A pending update whose release has no releaseTimestamp is the "skipped due to
+// missing releaseTimestamp" case we want to alert on. It must surface as
+// pending="true" together with releaseTimestamp="0".
+func TestDependencyUpdate_PendingWithoutReleaseTimestamp(t *testing.T) {
+	line := `{"msg":"packageFiles with updates","repository":"acme/repo","baseBranch":"main","config":{"dockerfile":[{"packageFile":"Dockerfile","deps":[{"depName":"example","packageName":"ghcr.io/acme/example","currentValue":"1.0.0","updates":[{"newVersion":"2.0.0","updateType":"major","pendingChecks":true}]}]}]}}`
+
+	labels := findUpdateSeries(t, parseLine(t, line), "example")
+	if labels == nil {
+		t.Fatal("no renovate_dependency_update series for depName=example")
+	}
+	if labels["pending"] != "true" {
+		t.Errorf("pending = %q, want \"true\"", labels["pending"])
+	}
+	if labels["releaseTimestamp"] != "0" {
+		t.Errorf("releaseTimestamp = %q, want \"0\"", labels["releaseTimestamp"])
+	}
+}
+
+// An update that has passed its checks must report pending="false".
+func TestDependencyUpdate_NotPending(t *testing.T) {
+	line := `{"msg":"packageFiles with updates","repository":"acme/repo","baseBranch":"main","config":{"dockerfile":[{"packageFile":"Dockerfile","deps":[{"depName":"ready","packageName":"ghcr.io/acme/ready","currentValue":"1.0.0","updates":[{"newVersion":"1.1.0","updateType":"minor","releaseTimestamp":"2026-06-01T00:00:00.000Z"}]}]}]}}`
+
+	labels := findUpdateSeries(t, parseLine(t, line), "ready")
+	if labels == nil {
+		t.Fatal("no renovate_dependency_update series for depName=ready")
+	}
+	if labels["pending"] != "false" {
+		t.Errorf("pending = %q, want \"false\"", labels["pending"])
+	}
+}


### PR DESCRIPTION
## What

Adds a `pending` label to the `renovate_dependency_update` metric, populated from Renovate's per-update `pendingChecks` flag (already present in the `packageFiles with updates` structured log).

## Why

Renovate can *withhold* an update via internal checks (e.g. `minimumReleaseAge`). Today the exporter emits `renovate_dependency_update` for such updates but there's no way to tell a pending update from one that will actually open a PR.

This is especially useful with `minimumReleaseAgeBehaviour=timestamp-required`: registries that don't publish a `releaseTimestamp` get held **forever**. Since the exporter already sets `releaseTimestamp="0"` when no timestamp is present, combining it with the new label:

```promql
renovate_dependency_update{releaseTimestamp="0", pending="true"} > 0
```

pinpoints exactly the updates blocked because their release has no timestamp — a clean alerting signal that self-clears once the package is allowlisted (`minimumReleaseAge: 0`).

## Changes

- `update` struct: parse `pendingChecks`.
- `renovate_dependency_update`: new `pending` label (`"true"`/`"false"`).
- Adds the first unit tests for `pkg/parser` (pending-without-timestamp, and not-pending).
- README metrics list updated.

Adding a label is backward compatible; existing queries/dashboards are unaffected.