### PR TITLE
fix(parser): don't crash on Renovate log lines larger than the buffer

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -34,33 +34,48 @@ type Repository struct {
 }
 
 func (p *parser) Parse() (map[string]*repository, error) {
-	scanner := bufio.NewScanner(p.r)
+	// Renovate can emit a single JSON log line larger than any fixed token size -- a
+	// repository that matches hundreds of files dumps a multi-megabyte debug line. The
+	// bufio.Scanner used here capped a line at BufferSize and returned bufio.ErrTooLong
+	// once a line exceeded it; that error propagates through push's RunE and
+	// rootCmd.Execute() to main(), which panic()s. The panic kills the process
+	// mid-stream, and when renovate-metrics is piped from a live `renovate` process it
+	// also closes the pipe and takes Renovate down with a broken pipe (EPIPE).
+	//
+	// bufio.Reader.ReadBytes has no such cap: it grows as needed and always drains to
+	// EOF, so an oversized line is handled (or skipped) rather than being fatal, and the
+	// stream is fully consumed either way.
+	reader := bufio.NewReaderSize(p.r, p.opts.BufferSize)
 
-	var b []byte
-	scanner.Buffer(b, p.opts.BufferSize)
-	for scanner.Scan() {
-		var line logLine
-		rawLine := scanner.Bytes()
-		if !bytes.Contains(rawLine, []byte(PackageFileUpdatesMessage)) && !bytes.Contains(rawLine, []byte(RepositoryFinishedMessage)) && !bytes.Contains(rawLine, []byte(BranchesInfoMessage)) {
-			continue
+	for {
+		rawLine, readErr := reader.ReadBytes('\n')
+
+		if len(rawLine) > 0 &&
+			(bytes.Contains(rawLine, []byte(PackageFileUpdatesMessage)) ||
+				bytes.Contains(rawLine, []byte(RepositoryFinishedMessage)) ||
+				bytes.Contains(rawLine, []byte(BranchesInfoMessage))) {
+			var line logLine
+			err := json.Unmarshal(rawLine, &line)
+			if err == nil {
+				if line.Repository != "" {
+					repository := p.repository(line.Repository)
+					if err := repository.Parse(line); err != nil {
+						p.opts.Logger.V(1).Info("failed to parse line", "error", err)
+					}
+				}
+			} else {
+				p.opts.Logger.V(1).Info("failed to decode json line", "error", err, "line", line)
+			}
 		}
 
-		err := json.Unmarshal(rawLine, &line)
-		if err == nil {
-			if line.Repository == "" {
-				continue
+		if readErr != nil {
+			if readErr == io.EOF {
+				return p.repositories, nil
 			}
 
-			repository := p.repository(line.Repository)
-			if err := repository.Parse(line); err != nil {
-				p.opts.Logger.V(1).Info("failed to parse line", "error", err)
-			}
-		} else {
-			p.opts.Logger.V(1).Info("failed to decode json line", "error", err, "line", line)
+			return p.repositories, readErr
 		}
 	}
-
-	return p.repositories, scanner.Err()
 }
 
 func (p *parser) repository(repository string) *repository {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -36,11 +36,11 @@ func TestParseHandlesOversizedLine(t *testing.T) {
 
 	repos, err := p.Parse()
 	if err != nil {
-		t.Fatalf("Parse returned an error on an oversized line: %v", err)
+		t.Fatalf("Parse() error = %v, want nil", err)
 	}
 
 	if _, ok := repos["org/small"]; !ok {
-		t.Fatalf("line after the oversized line was not parsed; got repos %v", keys(repos))
+		t.Fatalf("Parse() repos = %v, want to contain %q (line after the oversized line)", keys(repos), "org/small")
 	}
 }
 
@@ -55,10 +55,10 @@ func TestParseFinalLineWithoutTrailingNewline(t *testing.T) {
 
 	repos, err := p.Parse()
 	if err != nil {
-		t.Fatalf("Parse returned an error: %v", err)
+		t.Fatalf("Parse() error = %v, want nil", err)
 	}
 
 	if _, ok := repos["org/only"]; !ok {
-		t.Fatalf("final line without a trailing newline was not parsed; got repos %v", keys(repos))
+		t.Fatalf("Parse() repos = %v, want to contain %q (final line without a trailing newline)", keys(repos), "org/only")
 	}
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,0 +1,64 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func keys(m map[string]*repository) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+
+	return out
+}
+
+// Renovate can emit a single JSON log line larger than any fixed buffer size: a
+// repository that matches hundreds of files dumps a multi-megabyte debug line. Parsing
+// such a line must not error or panic, and parsing must continue with the lines that
+// follow it. Previously bufio.Scanner returned bufio.ErrTooLong here, which panicked the
+// whole process (cmd/main.go).
+func TestParseHandlesOversizedLine(t *testing.T) {
+	// A huge debug line that does not match any of the parsed message types (so it is
+	// skipped), far larger than the deliberately tiny BufferSize below.
+	huge := `{"repository":"org/huge","level":20,"msg":"` + strings.Repeat("x", 200000) + `"}`
+	// A normal line that is parsed; it contains RepositoryFinishedMessage.
+	small := `{"repository":"org/small","time":"2026-01-01T00:00:00Z","msg":"` + RepositoryFinishedMessage + `"}`
+	input := huge + "\n" + small + "\n"
+
+	p := NewParser(strings.NewReader(input), ParserOptions{
+		BufferSize: 64,
+		Logger:     logr.Discard(),
+	})
+
+	repos, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse returned an error on an oversized line: %v", err)
+	}
+
+	if _, ok := repos["org/small"]; !ok {
+		t.Fatalf("line after the oversized line was not parsed; got repos %v", keys(repos))
+	}
+}
+
+// The final line must be processed even when the stream has no trailing newline.
+func TestParseFinalLineWithoutTrailingNewline(t *testing.T) {
+	input := `{"repository":"org/only","time":"2026-01-01T00:00:00Z","msg":"` + RepositoryFinishedMessage + `"}`
+
+	p := NewParser(strings.NewReader(input), ParserOptions{
+		BufferSize: 64,
+		Logger:     logr.Discard(),
+	})
+
+	repos, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse returned an error: %v", err)
+	}
+
+	if _, ok := repos["org/only"]; !ok {
+		t.Fatalf("final line without a trailing newline was not parsed; got repos %v", keys(repos))
+	}
+}


### PR DESCRIPTION
## Problem
`renovate-metrics push` panics whenever Renovate emits a single JSON log line larger than the parser's buffer.

`Parse()` reads the stream with `bufio.Scanner` and `scanner.Buffer(b, BufferSize)` (default **10 MiB**). Renovate can emit a single log line larger than that — a repository that matches hundreds of files dumps a multi-megabyte debug line (we observed **~10.06 MiB** in production, from a repo with 305 flux files). Once a line exceeds the cap, `Scan()` stops and `scanner.Err()` returns `bufio.ErrTooLong` (`"token too long"`).

That error propagates: `Parse()` → `push`'s `RunE` → `rootCmd.Execute()` → `main()`, which does `panic(err)`. The panic kills the process **mid-stream**. When `renovate-metrics push` is piped from a live `renovate` process (the documented usage, `renovate | ... | renovate-metrics push`), the dying reader also closes the pipe, so Renovate itself then fails with `write EPIPE` and exits non-zero. In a Kubernetes `Job` with `restartPolicy: OnFailure` this crash-loops the whole run.

## Fix
Replace `bufio.Scanner` with `bufio.Reader.ReadBytes('\n')`, which has no token-size cap: it grows as needed and always drains to EOF. An oversized line is parsed (or skipped by the existing message pre-filter) rather than fatal, and the stream is always fully consumed. The message filter and all other behavior are unchanged; `--buffer-size` now sizes the initial read buffer instead of capping line length.

## Tests
Adds `pkg/parser/parser_test.go` (the package had none):
- `TestParseHandlesOversizedLine` — an oversized line followed by a normal line; asserts no error and the later line is still parsed. **Fails on `main` with `bufio.Scanner: token too long`**, passes with this change.
- `TestParseFinalLineWithoutTrailingNewline` — the final line is processed even without a trailing `\n`.

`go build ./...`, `go vet`, `gofmt`, and `go test ./pkg/parser/...` all pass.

## Notes
Opening as a **draft** for maintainer feedback on approach (e.g. whether you'd prefer to also lower/keep the `--buffer-size` default now that it no longer bounds line length). Happy to adjust.